### PR TITLE
Add automatic YouTube embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can use this feature to:
   - Paragraphs, line breaks, and bullet lists (`-` or `*`) are preserved.
   - Inline code (`` `like this` ``) and fenced code blocks (```lang) are rendered using proper HTML code tags.
   - Safe HTML tags like `<b>`, `<i>`, and `<a href="...">` are allowed and sanitized.
+- **YouTube Embeds**: Bookmarks that link to YouTube automatically include an embedded video player above your note.
 - **Metadata Embedded**: Posts include embedded metadata (like Raindrop ID and tags) for filtering or custom display logic.
 - **RSS Feed Friendly**: Works well with Ghost’s RSS system to support custom feeds using the `links` tag.
 

--- a/index.js
+++ b/index.js
@@ -40,11 +40,41 @@ async function getLatestRaindropBookmark() {
 }
 
 // Check if a bookmark has a note or highlight or note on a highlight
+function getYouTubeVideoId(url) {
+    try {
+        const parsed = new URL(url);
+        const { hostname, pathname, searchParams } = parsed;
+
+        if (hostname === 'youtu.be') {
+            return pathname.slice(1);
+        }
+
+        if (hostname === 'youtube.com' || hostname === 'www.youtube.com' || hostname === 'm.youtube.com') {
+            if (pathname === '/watch') {
+                return searchParams.get('v');
+            }
+            const shortsMatch = pathname.match(/^\/shorts\/([\w-]+)/);
+            if (shortsMatch) {
+                return shortsMatch[1];
+            }
+            const embedMatch = pathname.match(/^\/embed\/([\w-]+)/);
+            if (embedMatch) {
+                return embedMatch[1];
+            }
+        }
+    } catch (e) {
+        return null;
+    }
+    return null;
+}
+
+// Check if a bookmark has a note, highlight, highlight note, or is a YouTube link
 function shouldProcessBookmark(bookmark) {
     const hasNote = !!bookmark.note?.trim();
     const hasHighlights = Array.isArray(bookmark.highlights) && bookmark.highlights.length > 0;
     const hasHighlightNotes = bookmark.highlights?.some(h => h.note?.trim());
-    return hasNote || hasHighlights || hasHighlightNotes;
+    const isYouTube = !!getYouTubeVideoId(bookmark.link);
+    return hasNote || hasHighlights || hasHighlightNotes || isYouTube;
 }
 
 // Escape HTML to avoid malformed posts
@@ -150,7 +180,15 @@ function formatGhostContent(bookmark) {
         `raindrop-tags="${(tags || []).join(',')}">`
     );
 
-    // Add bookmark note first with structured formatting
+    // If bookmark link is a YouTube URL, embed the video player
+    const videoId = getYouTubeVideoId(link);
+    if (videoId) {
+        htmlParts.push(
+            `<div class="youtube-embed"><iframe width="560" height="315" src="https://www.youtube.com/embed/${videoId}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>`
+        );
+    }
+
+    // Add bookmark note with structured formatting
     if (note.trim()) {
         htmlParts.push(convertNoteToHtml(note));
     }


### PR DESCRIPTION
## Summary
- embed YouTube videos when Raindrop link points to YouTube
- process bookmarks for YouTube links even if they lack notes/highlights
- document YouTube embedding capability

## Testing
- `node -c index.js`

------
https://chatgpt.com/codex/tasks/task_b_68447d3f1ee88326aae9165c8a770250