### PR TITLE
Add automatic YouTube embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can use this feature to:
   - Paragraphs, line breaks, and bullet lists (`-` or `*`) are preserved.
   - Inline code (`` `like this` ``) and fenced code blocks (```lang) are rendered using proper HTML code tags.
   - Safe HTML tags like `<b>`, `<i>`, and `<a href="...">` are allowed and sanitized.
+- **YouTube Embeds**: Bookmarks linking to YouTube (including `youtu.be` and `youtube.com` URLs) automatically include an embedded player above your note.
 - **Metadata Embedded**: Posts include embedded metadata (like Raindrop ID and tags) for filtering or custom display logic.
 - **RSS Feed Friendly**: Works well with Ghost’s RSS system to support custom feeds using the `links` tag.
 


### PR DESCRIPTION
## Summary
- embed YouTube videos when Raindrop link points to YouTube
- process bookmarks for YouTube links even if they lack notes/highlights
- document YouTube embedding capability
- handle additional YouTube domains

## Testing
- `node -c index.js`

------
https://chatgpt.com/codex/tasks/task_b_68447d3f1ee88326aae9165c8a770250